### PR TITLE
[PR] Update maps embed shortcode with current information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # WSU Maps Shortcode
 
-This plugin provides a shortcode to embed maps from http://maps.wsu.edu in your content.
+This plugin provides a `[wsuwp_map]` shortcode to embed maps from https://map.wsu.edu in your content.
 
-The only required attribute is the map's ID. When you click "Link/Embed" while on maps.wsu.edu, you will receive HTML that looks like this:
+The only required attribute is the map's ID or map name.
+
+## Embed maps by ID
+
+When you click "Link/Embed" while on https://map.wsu.edu, you will receive HTML that looks like this:
 
 ```
 <iframe width="214" height="161" frameborder="0"
         scrolling="no" marginheight="0" marginwidth="0"
-        src="http://map.wsu.edu/t/68DE9EF" ></iframe>
+        src="https://map.wsu.edu/t/68DE9EF" ></iframe>
 ```
 
 The piece to copy as the map ID in the above HTML is `68DE9EF`.
@@ -29,6 +33,10 @@ The available sizes are as follows:
 
 A custom size can be used by defining the width and height manually: `[wsuwp_map id="68DE9EF" width=400 height=200]`
 
+## Embed custom maps by name
+
 In some cases, you may have a custom map created by University Communications. Use your alias as part of the shortcode rather than the ID:
 
-`[wsuwp_map alias="my-custom-code" size="largest"]`
+`[wsuwp_map map="my-custom-code"]`
+
+This will embed the map in a container `DIV` with the class of `wsuwp-map-container` that can be targetted with CSS for sizing.

--- a/wsuwp-maps.php
+++ b/wsuwp-maps.php
@@ -59,7 +59,7 @@ class WSUWP_Maps {
 				return '';
 			}
 
-			$content = '<div id="map-embed-' . $map_path . '"></div>';
+			$content = '<div id="map-embed-' . $map_path . '" class="wsuwp-map-container"></div>';
 			$content .= '<script>var map_view_scripts_block = true; var map_view_id = "map-embed-' . esc_js( $map_path ) .'";</script>';
 
 			wp_enqueue_script( 'wsu-map-embed', esc_url( 'https://map.wsu.edu/embed/' . $map_path ), array( 'jquery' ), false, true );

--- a/wsuwp-maps.php
+++ b/wsuwp-maps.php
@@ -3,7 +3,7 @@
 Plugin Name: WSUWP Maps
 Version: 0.3.2
 Plugin URI: https://web.wsu.edu/
-Description: A shortcode to display an embedded map from maps.wsu.edu.
+Description: A shortcode to display an embedded map from map.wsu.edu.
 Author: washingtonstateuniversity, jeremyfelt, jeremybass
 Author URI: https://web.wsu.edu/
 */
@@ -34,7 +34,7 @@ class WSUWP_Maps {
 		$post = get_post();
 		if ( isset( $post->post_content ) && has_shortcode( $post->post_content, 'wsuwp_map' ) ) {
 			wp_enqueue_style( 'jquery-ui-smoothness', 'https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.3/themes/smoothness/jquery-ui.min.css', array(), false );
-			wp_enqueue_style( 'wsu-map-style', 'https://beta.maps.wsu.edu/content/dis/css/map.view.styles.css', array(), false );
+			wp_enqueue_style( 'wsu-map-style', 'https://map.wsu.edu/content/dis/css/map.view.styles.css', array(), false );
 		}
 	}
 
@@ -64,7 +64,7 @@ class WSUWP_Maps {
 			$content = '<div id="map-embed-' . $map_path . '"></div>';
 			$content .= '<script>var map_view_scripts_block = true; var map_view_id = "map-embed-' . esc_js( $map_path ) .'";</script>';
 
-			wp_enqueue_script( 'wsu-map-embed', esc_url( 'https://beta.maps.wsu.edu/embed/ ' . $map_path ), array( 'jquery' ), false, true );
+			wp_enqueue_script( 'wsu-map-embed', esc_url( 'https://map.wsu.edu/embed/ ' . $map_path ), array( 'jquery' ), false, true );
 
 			return $content;
 

--- a/wsuwp-maps.php
+++ b/wsuwp-maps.php
@@ -45,11 +45,8 @@ class WSUWP_Maps {
 		$defaults = array(
 			'size' => 'medium',
 			'id' => '',
-			'alias' => '',
 			'width' => '',
 			'height' => '',
-			'version' => '',
-			'scheme' => 'https',
 			'map' => '',
 		);
 		$att = shortcode_atts( $defaults, $attributes );

--- a/wsuwp-maps.php
+++ b/wsuwp-maps.php
@@ -64,7 +64,7 @@ class WSUWP_Maps {
 			$content = '<div id="map-embed-' . $map_path . '"></div>';
 			$content .= '<script>var map_view_scripts_block = true; var map_view_id = "map-embed-' . esc_js( $map_path ) .'";</script>';
 
-			wp_enqueue_script( 'wsu-map-embed', esc_url( 'https://map.wsu.edu/embed/ ' . $map_path ), array( 'jquery' ), false, true );
+			wp_enqueue_script( 'wsu-map-embed', esc_url( 'https://map.wsu.edu/embed/' . $map_path ), array( 'jquery' ), false, true );
 
 			return $content;
 

--- a/wsuwp-maps.php
+++ b/wsuwp-maps.php
@@ -54,7 +54,8 @@ class WSUWP_Maps {
 		);
 		$att = shortcode_atts( $defaults, $attributes );
 
-		if ( 'beta' === $att['version'] ) {
+		// The map attribute is used for newer style maps. ID is used for older style maps.
+		if ( ! empty( $att['map'] ) ) {
 			$map_path = sanitize_title_with_dashes( $attributes['map'] );
 
 			if ( empty( $map_path ) ) {
@@ -68,14 +69,8 @@ class WSUWP_Maps {
 
 			return $content;
 
-		} else {
-			if ( '' !== $att['id'] ) {
-				$map_url = 'https://map.wsu.edu/t/' . sanitize_key( $att['id'] );
-			} elseif ( '' !== $att['alias'] ) {
-				$map_url = 'https://map.wsu.edu/rt/' . sanitize_key( $att['alias'] ) . '?mode=standalone';
-			} else {
-				$map_url = 'https://map.wsu.edu/t/942CFE9C'; // Default to the WSU label.
-			}
+		} elseif ( ! empty( $att['id'] ) ) {
+			$map_url = 'https://map.wsu.edu/t/' . sanitize_key( $att['id'] );
 
 			if ( 'small' === $att['size'] ) {
 				$x = 214;
@@ -106,6 +101,8 @@ class WSUWP_Maps {
 
 			return $html;
 		}
+
+		return '<!-- no valid map parameters -->';
 	}
 }
 new WSUWP_Maps();


### PR DESCRIPTION
- All URLs should use https://map.wsu.edu
- Support only `id` and `map` shortcode attributes
- Add a container class when using a named map alias.
